### PR TITLE
Fix bundle gem caching

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,8 +14,6 @@ jobs:
         run: gem install bundler
       - name: Display the versions used
         run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
-      - name: Force update gems
-        run: rm Gemfile.lock || true
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
@@ -44,8 +42,6 @@ jobs:
         run: gem install bundler
       - name: Display the versions used
         run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
-      - name: Force update gems
-        run: rm Gemfile.lock || true
       - uses: actions/cache@v2
         with:
           path: vendor/bundle

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,8 @@ jobs:
         run: gem install bundler
       - name: Display the versions used
         run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
-      - uses: actions/cache@v2
+      - name: Cache gem bundle
+        uses: actions/cache@v2
         with:
           path: vendor/bundle
           key: ruby-2.4.5-gems-${{ hashFiles('**/Gemfile') }}
@@ -42,7 +43,8 @@ jobs:
         run: gem install bundler
       - name: Display the versions used
         run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
-      - uses: actions/cache@v2
+      - name: Cache gem bundle
+        uses: actions/cache@v2
         with:
           path: vendor/bundle
           key: ruby-2.5.7-gems-${{ hashFiles('**/Gemfile') }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,3 +82,5 @@ jobs:
       env:
        FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
        REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases
+
+       

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       PUPPET_GEM_VERSION: '~> 5'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install bundler
         run: gem install bundler
       - name: Display the versions used
@@ -39,7 +39,7 @@ jobs:
     env:
       PUPPET_GEM_VERSION: '~> 6'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install bundler
         run: gem install bundler
       - name: Display the versions used
@@ -77,7 +77,7 @@ jobs:
         fi
     - name: Clone repository
       if: steps.check-tag.outputs.match == 'true'
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         ref: ${{ env.RELEASE_VERSION }}
     - name: Build and publish module

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,13 +17,12 @@ jobs:
       - name: Cache gem bundle
         uses: actions/cache@v2
         with:
-          path: vendor/bundle
+          path: /usr/local/bundle
           key: ruby-2.4.5-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: |
             ruby-2.4.5-gems-
       - name: Install/update dependencies
         run: |
-          bundle config path vendor/bundle
           bundle config set without 'system_tests'
           bundle install --jobs $(nproc) --retry 3
       - name: Syntax check
@@ -46,13 +45,12 @@ jobs:
       - name: Cache gem bundle
         uses: actions/cache@v2
         with:
-          path: vendor/bundle
+          path: /usr/local/bundle
           key: ruby-2.5.7-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: |
             ruby-2.5.7-gems-
       - name: Install/update dependencies
         run: |
-          bundle config path vendor/bundle
           bundle config set without 'system_tests'
           bundle install --jobs $(nproc) --retry 3
       - name: Syntax check


### PR DESCRIPTION
The bundle path is hardcoded for some reason, so I just pointed the caching machanism there.
It shaved off 15 seconds from the puppet 5 run and 25 seconds from the puppet 6 run.
Too bad, the total workflow is still 2+ minutes and I'm wondering if we aren't wasting our time with containers
and shouldn't use the [github VM](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md) directly instead. 
It's an ubuntu 18.04, but we are root, with direct access to the OS and the ability to cache stuff like compiled versions of ruby and gems, I thing we can run the whole thing way faster...

I'm gonna start a fresh branch with blank workflow and see if I can install rbenv and cache all we need to make this run as fast as it shoult be.