### PR TITLE
CI without containers saves 30 seconds

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,37 @@ jobs:
       run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
     - name: Test suite
       run: bundle exec rake parallel_spec
+
+  build_puppet6:
+    name: Validate for Puppet 6
+    runs-on: ubuntu-latest
+    env:
+      PUPPET_GEM_VERSION: '~> 6'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.5.7
+    - name: Display the versions used
+      run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
+    - name: Cache gem bundle
+      uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ruby-2.5.7-gems-${{ hashFiles('**/Gemfile') }}
+        restore-keys: |
+          ruby-2.5.7-gems-
+    - name: Install/update dependencies
+      run: |
+        bundle config path vendor/bundle
+        bundle config set without 'system_tests'
+        bundle install --jobs $(nproc) --retry 3
+    - name: Syntax check
+      run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+    - name: Test suite
+      run: bundle exec rake parallel_spec
+
+
 #
 #  build_puppet6:
 #    name: Validate for Puppet 6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,25 +12,23 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.4.5
-    - name: Install bundler
-      run: gem install bundler
     - name: Display the versions used
       run: ruby --version && echo -n 'gem ' && gem --version && bundle --version && which ruby
-#      - name: Cache gem bundle
-#        uses: actions/cache@v2
-#        with:
-#          path: /usr/local/bundle
-#          key: ruby-2.4.5-gems-${{ hashFiles('**/Gemfile') }}
-#          restore-keys: |
-#            ruby-2.4.5-gems-
-#      - name: Install/update dependencies
-#        run: |
-#          bundle config set without 'system_tests'
-#          bundle install --jobs $(nproc) --retry 3
-#      - name: Syntax check
-#        run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
-#      - name: Test suite
-#        run: bundle exec rake parallel_spec
+    - name: Cache gem bundle
+      uses: actions/cache@v2
+      with:
+        path: /usr/local/bundle
+        key: ruby-2.4.5-gems-${{ hashFiles('**/Gemfile') }}
+        restore-keys: |
+          ruby-2.4.5-gems-
+    - name: Install/update dependencies
+      run: |
+        bundle config set without 'system_tests'
+        bundle install --jobs $(nproc) --retry 3
+    - name: Syntax check
+      run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+    - name: Test suite
+      run: bundle exec rake parallel_spec
 #
 #  build_puppet6:
 #    name: Validate for Puppet 6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,16 +13,17 @@ jobs:
       with:
         ruby-version: 2.4.5
     - name: Display the versions used
-      run: ruby --version && echo -n 'gem ' && gem --version && bundle --version && which ruby
+      run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
     - name: Cache gem bundle
       uses: actions/cache@v2
       with:
-        path: /usr/local/bundle
+        path: vendor/bundle
         key: ruby-2.4.5-gems-${{ hashFiles('**/Gemfile') }}
         restore-keys: |
           ruby-2.4.5-gems-
     - name: Install/update dependencies
       run: |
+        bundle config path vendor/bundle
         bundle config set without 'system_tests'
         bundle install --jobs $(nproc) --retry 3
     - name: Syntax check

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,84 +5,83 @@ jobs:
   build_puppet5:
     name: Validate for Puppet 5
     runs-on: ubuntu-latest
-    container: ruby:2.4.5
     env:
       PUPPET_GEM_VERSION: '~> 5'
     steps:
-      - uses: actions/checkout@v1
-      - name: Install bundler
-        run: gem install bundler
-      - name: Display the versions used
-        run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
-      - name: Force update gems
-        run: rm Gemfile.lock || true
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ruby-2.4.5-gems-${{ hashFiles('**/Gemfile') }}
-          restore-keys: |
-            ruby-2.4.5-gems-
-      - name: Install/update dependencies
-        run: |
-          bundle config path vendor/bundle
-          bundle config set without 'system_tests'
-          bundle install --jobs $(nproc) --retry 3
-      - name: Syntax check
-        run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
-      - name: Test suite
-        run: bundle exec rake parallel_spec
-
-  build_puppet6:
-    name: Validate for Puppet 6
-    runs-on: ubuntu-latest
-    container: ruby:2.5.7
-    env:
-      PUPPET_GEM_VERSION: '~> 6'
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install bundler
-        run: gem install bundler
-      - name: Display the versions used
-        run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
-      - name: Force update gems
-        run: rm Gemfile.lock || true
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ruby-2.5.7-gems-${{ hashFiles('**/Gemfile') }}
-          restore-keys: |
-            ruby-2.5.7-gems-
-      - name: Install/update dependencies
-        run: |
-          bundle config path vendor/bundle
-          bundle config set without 'system_tests'
-          bundle install --jobs $(nproc) --retry 3
-      - name: Syntax check
-        run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
-      - name: Test suite
-        run: bundle exec rake parallel_spec
-
-  build_forge:
-    name: Build and publish to Puppet Forge
-    runs-on: ubuntu-latest
-    needs: [ build_puppet5, build_puppet6 ]
-    steps:
-    - name: Get latest tag
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
-    - name: Check tag
-      id: check-tag
-      run: |
-        if [[ $RELEASE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo ::set-output name=match::true
-        fi
-    - name: Clone repository
-      if: steps.check-tag.outputs.match == 'true'
-      uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
       with:
-        ref: ${{ env.RELEASE_VERSION }}
-    - name: Build and publish module
-      if: steps.check-tag.outputs.match == 'true'
-      uses: barnumbirr/action-forge-publish@v2.3.0
-      env:
-       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
-       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases
+        ruby-version: 2.4.5
+    - name: Install bundler
+      run: gem install bundler
+    - name: Display the versions used
+      run: ruby --version && echo -n 'gem ' && gem --version && bundle --version && which ruby
+#      - name: Cache gem bundle
+#        uses: actions/cache@v2
+#        with:
+#          path: /usr/local/bundle
+#          key: ruby-2.4.5-gems-${{ hashFiles('**/Gemfile') }}
+#          restore-keys: |
+#            ruby-2.4.5-gems-
+#      - name: Install/update dependencies
+#        run: |
+#          bundle config set without 'system_tests'
+#          bundle install --jobs $(nproc) --retry 3
+#      - name: Syntax check
+#        run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+#      - name: Test suite
+#        run: bundle exec rake parallel_spec
+#
+#  build_puppet6:
+#    name: Validate for Puppet 6
+#    runs-on: ubuntu-latest
+#    container: ruby:2.5.7
+#    env:
+#      PUPPET_GEM_VERSION: '~> 6'
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Install bundler
+#        run: gem install bundler
+#      - name: Display the versions used
+#        run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
+#      - name: Cache gem bundle
+#        uses: actions/cache@v2
+#        with:
+#          path: /usr/local/bundle
+#          key: ruby-2.5.7-gems-${{ hashFiles('**/Gemfile') }}
+#          restore-keys: |
+#            ruby-2.5.7-gems-
+#      - name: Install/update dependencies
+#        run: |
+#          bundle config set without 'system_tests'
+#          bundle install --jobs $(nproc) --retry 3
+#      - name: Syntax check
+#        run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+#      - name: Test suite
+#        run: bundle exec rake parallel_spec
+#
+#  build_forge:
+#    name: Build and publish to Puppet Forge
+#    runs-on: ubuntu-latest
+#    needs: [ build_puppet5, build_puppet6 ]
+#    steps:
+#    - name: Get latest tag
+#      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+#    - name: Check tag
+#      id: check-tag
+#      run: |
+#        if [[ $RELEASE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+#          echo ::set-output name=match::true
+#        fi
+#    - name: Clone repository
+#      if: steps.check-tag.outputs.match == 'true'
+#      uses: actions/checkout@v2
+#      with:
+#        ref: ${{ env.RELEASE_VERSION }}
+#    - name: Build and publish module
+#      if: steps.check-tag.outputs.match == 'true'
+#      uses: barnumbirr/action-forge-publish@v2.3.0
+#      env:
+#       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
+#       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases
+#

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,58 +60,27 @@ jobs:
     - name: Test suite
       run: bundle exec rake parallel_spec
 
-
-#
-#  build_puppet6:
-#    name: Validate for Puppet 6
-#    runs-on: ubuntu-latest
-#    container: ruby:2.5.7
-#    env:
-#      PUPPET_GEM_VERSION: '~> 6'
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Install bundler
-#        run: gem install bundler
-#      - name: Display the versions used
-#        run: ruby --version && echo -n 'gem ' && gem --version && bundle --version
-#      - name: Cache gem bundle
-#        uses: actions/cache@v2
-#        with:
-#          path: /usr/local/bundle
-#          key: ruby-2.5.7-gems-${{ hashFiles('**/Gemfile') }}
-#          restore-keys: |
-#            ruby-2.5.7-gems-
-#      - name: Install/update dependencies
-#        run: |
-#          bundle config set without 'system_tests'
-#          bundle install --jobs $(nproc) --retry 3
-#      - name: Syntax check
-#        run: bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
-#      - name: Test suite
-#        run: bundle exec rake parallel_spec
-#
-#  build_forge:
-#    name: Build and publish to Puppet Forge
-#    runs-on: ubuntu-latest
-#    needs: [ build_puppet5, build_puppet6 ]
-#    steps:
-#    - name: Get latest tag
-#      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
-#    - name: Check tag
-#      id: check-tag
-#      run: |
-#        if [[ $RELEASE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-#          echo ::set-output name=match::true
-#        fi
-#    - name: Clone repository
-#      if: steps.check-tag.outputs.match == 'true'
-#      uses: actions/checkout@v2
-#      with:
-#        ref: ${{ env.RELEASE_VERSION }}
-#    - name: Build and publish module
-#      if: steps.check-tag.outputs.match == 'true'
-#      uses: barnumbirr/action-forge-publish@v2.3.0
-#      env:
-#       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
-#       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases
-#
+  build_forge:
+    name: Build and publish to Puppet Forge
+    runs-on: ubuntu-latest
+    needs: [ build_puppet5, build_puppet6 ]
+    steps:
+    - name: Get latest tag
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+    - name: Check tag
+      id: check-tag
+      run: |
+        if [[ $RELEASE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo ::set-output name=match::true
+        fi
+    - name: Clone repository
+      if: steps.check-tag.outputs.match == 'true'
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.RELEASE_VERSION }}
+    - name: Build and publish module
+      if: steps.check-tag.outputs.match == 'true'
+      uses: barnumbirr/action-forge-publish@v2.3.0
+      env:
+       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
+       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases


### PR DESCRIPTION
Turns out, not using containers and just installing the right version of ruby in Github's environment shaves off 30 seconds of the test suite. And I think that it's just the time to download the containers on the host that runs that job. 
Plus, having direct access to the OS matches our idea of having an internal runner that is iso-prod.